### PR TITLE
Add `use_user` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ optional arguments:
                        self-hosting it (default: https://ntfy.sh)
   --admin ADMIN        username for admin messages (like when a notification
                        is failed to get parsed) (default: admin)
+  --use_user USE_USER  whether you want to send messages to each user separately
+                       or instead send them to a single channel (default: true, sends them separately)
   --hostname HOSTNAME  master node hostname, is used in notification channel
                        name: <url>/cs_<hostname>_<username> (default: cmm-1)
 ```

--- a/server.py
+++ b/server.py
@@ -132,16 +132,15 @@ class Ntfy:
 
         return user, header, message
 
-    def post(self, header: str, message: str, user: str, priority: str) -> Response:
+    def post(
+        self, header: str, message: str, user: str, priority: str, use_user: bool = True
+    ) -> Response:
         assert priority in ("max", "urgent", "high", "default", "low", "min"), priority
 
-        url = f"{self.source}_{user}"
+        url = f"{self.source}_{user}" if use_user else self.source
         headers = {"Title": header, "Priority": priority}
-        target = f"{self.source}_{user}"
         logging.info(f"posting to url={url} message={message} with headers={headers}")
-        rv = requests.post(
-            target, data=message.encode(encoding="utf-8"), headers=headers
-        )
+        rv = requests.post(url, data=message.encode(encoding="utf-8"), headers=headers)
         return rv
 
     def post_default(self, header: str, message: str, user: str) -> Response:


### PR DESCRIPTION
Updated usage:

```
usage: cryosparcm call python3 server.py [-h] [--url URL] [--admin ADMIN] [--hostname HOSTNAME]

optional arguments:
  -h, --help           show this help message and exit
  --url URL            location of ntfy server (change from default if you're
                       self-hosting it (default: https://ntfy.sh)
  --admin ADMIN        username for admin messages (like when a notification
                       is failed to get parsed) (default: admin)
  --use_user USE_USER  whether you want to send messages to each user separately
                       or instead send them to a single channel (default: true, sends them separately)
  --hostname HOSTNAME  master node hostname, is used in notification channel
                       name: <url>/cs_<hostname>_<username> (default: cmm-1)
```